### PR TITLE
Fix build errors

### DIFF
--- a/OctaneTagWritingTest/JobStrategies/JobStrategy8MultipleReaderEnduranceStrategy.cs
+++ b/OctaneTagWritingTest/JobStrategies/JobStrategy8MultipleReaderEnduranceStrategy.cs
@@ -291,14 +291,14 @@ namespace OctaneTagWritingTest.JobStrategies
             verifierSettings.Session = (ushort)verifierReaderSettings.Session;
 
             verifierSettings.Gpis.EnableAll();
-            verifierSettings.Gpis.GetGpi(1).DebounceInMs = applicationConfig.GpiDebounceInMs;
-            verifierSettings.Gpis.GetGpi(2).DebounceInMs = applicationConfig.GpiDebounceInMs;
+            verifierSettings.Gpis.GetGpi(1).DebounceInMs = (uint)applicationConfig.GpiDebounceInMs;
+            verifierSettings.Gpis.GetGpi(2).DebounceInMs = (uint)applicationConfig.GpiDebounceInMs;
 
             verifierSettings.Gpos.GetGpo(1).Mode = GpoMode.Pulsed;
-            verifierSettings.Gpos.GetGpo(1).GpoPulseDurationMsec = applicationConfig.GpoPulseDurationMs;
+            verifierSettings.Gpos.GetGpo(1).GpoPulseDurationMsec = (uint)applicationConfig.GpoPulseDurationMs;
 
             verifierSettings.Gpos.GetGpo(2).Mode = GpoMode.Pulsed;
-            verifierSettings.Gpos.GetGpo(2).GpoPulseDurationMsec = applicationConfig.GpoPulseDurationMs;
+            verifierSettings.Gpos.GetGpo(2).GpoPulseDurationMsec = (uint)applicationConfig.GpoPulseDurationMs;
 
             verifierSettings.AutoStart.Mode = AutoStartMode.GpiTrigger;
             verifierSettings.AutoStart.GpiPortNumber = 1;

--- a/OctaneTagWritingTest/Program.cs
+++ b/OctaneTagWritingTest/Program.cs
@@ -21,8 +21,10 @@ namespace OctaneTagWritingTest
                 return;
             }
 
-            // Initialize configuration
-            ApplicationConfig config;
+            // Initialize configuration with defaults to satisfy compiler
+            // The configuration will be replaced based on command line
+            // arguments or interactive input.
+            ApplicationConfig config = new ApplicationConfig();
             bool isRunningInDebugMode = false;
 
 #if DEBUG


### PR DESCRIPTION
## Summary
- initialize config variable in Program to avoid use-before-assignment
- cast debounce and pulse values to uint in JobStrategy8MultipleReaderEnduranceStrategy

## Testing
- `dotnet build OctaneTagWritingTest/OctaneTagWritingTest.csproj --configuration Release --no-restore` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686eaa7c3c4083238d940da987831e82