### PR TITLE
Fix dotnet publish step for Windows

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -23,6 +23,7 @@ jobs:
         run: dotnet build OctaneTagWritingTest/OctaneTagWritingTest.csproj --configuration Release --no-restore
 
       - name: Publish output for Windows
+        shell: bash
         run: |
           dotnet publish OctaneTagWritingTest/OctaneTagWritingTest.csproj \
             --configuration Release \


### PR DESCRIPTION
## Summary
- fix multi-line command in dotnet workflow by running step using bash

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ebe320ae48323b8ba80cc847f86a5