### PR TITLE
Fix dotnet publish step

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,7 +17,7 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Restore dependencies
-        run: dotnet restore OctaneTagWritingTest/OctaneTagWritingTest.csproj
+        run: dotnet restore OctaneTagWritingTest/OctaneTagWritingTest.csproj --runtime win-x64
 
       - name: Build solution
         run: dotnet build OctaneTagWritingTest/OctaneTagWritingTest.csproj --configuration Release --no-restore
@@ -30,8 +30,7 @@ jobs:
             --runtime win-x64 \
             --self-contained true \
             -p:PublishSingleFile=true \
-            --output ./publish \
-            --no-build
+            --output ./publish
 
       # Optional: Run unit tests if needed
       # - name: Run tests


### PR DESCRIPTION
## Summary
- update workflow restore step to include runtime
- remove no-build from publish command

## Testing
- `dotnet test TagUtils.Tests/TagUtils.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_686ec697fb048323b8d311a3935402c5