### PR TITLE
Fix config.json parsing issues

### DIFF
--- a/OctaneTagWritingTest/config.json
+++ b/OctaneTagWritingTest/config.json
@@ -4,17 +4,19 @@
   "VerifierHostname": "192.168.1.103",
   "TestDescription": "TesteSGTIN",
   "Sgtin96Enabled": true,
-  "Sgtin96SourceGtin": "80614141123458", // para gravacao usando GTIN do produto
+  "Sgtin96SourceGtin": "80614141123458",
 
   "EpcHeader": "B1",
   "EpcPlainItemCode": "33449900112222",
-  "Sku": "334499001122", // Para rotina do Checkbox
+  "Sku": "334499001122",
 
   "Quantity": 1,
 
   "_comment_gpi": "Configurações GPI para JobStrategy8MultipleReaderEnduranceStrategy",
   "UseGpiForVerification": true,
   "GpiTriggerStateToProcessVerification": false,
+  "GpiDebounceInMs": 100,
+  "GpoPulseDurationMs": 100,
 
   "DetectorAntennas": {
     "Antennas": [
@@ -132,5 +134,4 @@
   "VerifierTagMask": "0017",
   "VerifierBitCount": 16,
   "VerifierFilterOp": "NotMatch",
-  "VerifierFilterMode": "OnlyFilter1"
-}
+  "VerifierFilterMode": "OnlyFilter1"}


### PR DESCRIPTION
## Summary
- remove inline comments from `config.json`
- add `GpiDebounceInMs` and `GpoPulseDurationMs` settings

## Testing
- `dotnet test TagUtils.Tests/TagUtils.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686ed44070808323982a26fccbc1da50