### PR TITLE
Handle blank options and improve quit handling

### DIFF
--- a/OctaneTagWritingTest/Program.cs
+++ b/OctaneTagWritingTest/Program.cs
@@ -191,7 +191,9 @@ namespace OctaneTagWritingTest
                 manager.DisplayMenu();
                 Console.Write("Choose an option (or 'q' to quit): ");
                 string option = Console.ReadLine();
-                if (option?.ToLower() == "q")
+                if (string.IsNullOrWhiteSpace(option))
+                    continue;
+                if (string.Equals(option, "q", StringComparison.OrdinalIgnoreCase))
                     break;
 
                 // Create cancellation token source for the test
@@ -213,7 +215,7 @@ namespace OctaneTagWritingTest
                         }
                         Thread.Sleep(100); // Reduce CPU usage
                     }
-                });
+                }, cts.Token);
 
                 try
                 {


### PR DESCRIPTION
## Summary
- ignore blank menu entries and allow case-insensitive quit option
- cancel key monitor task using a passed cancellation token

## Testing
- `dotnet test OctaneTagWritingTest/OctaneTagWritingTest.sln` *(fails: FromSgtin96Hex_ShouldPreserveOriginalGTIN_WhenDecodedBack)*

------
https://chatgpt.com/codex/tasks/task_e_68b06f1dba74832385e9694f4c88dd7a