### PR TITLE
Use UTC log timestamps and await cancellable key monitor

### DIFF
--- a/OctaneTagWritingTest/LoggingConfiguration.cs
+++ b/OctaneTagWritingTest/LoggingConfiguration.cs
@@ -16,8 +16,8 @@ namespace OctaneTagWritingTest
         /// <param name="logLevel">Minimum log level (default: Information)</param>
         public static void ConfigureLogging(string testDescription = "default", LogEventLevel logLevel = LogEventLevel.Information)
         {
-            var logFileName = $"logs/octane-tag-writing-{testDescription}-{DateTime.Now:yyyyMMdd-HHmmss}.log";
-            var errorLogFileName = $"logs/octane-tag-writing-{testDescription}-errors-{DateTime.Now:yyyyMMdd-HHmmss}.log";
+            var logFileName = $"logs/octane-tag-writing-{testDescription}-{DateTime.UtcNow:yyyyMMdd-HHmmss}.log";
+            var errorLogFileName = $"logs/octane-tag-writing-{testDescription}-errors-{DateTime.UtcNow:yyyyMMdd-HHmmss}.log";
 
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Is(logLevel)


### PR DESCRIPTION
## Summary
- run key monitor on a background Task with a cancellation token and await it to handle OperationCanceledException
- generate log filenames with UTC timestamps to avoid timezone issues

## Testing
- ❌ `dotnet test TagUtils.Tests/TagUtils.Tests.csproj --logger "console;verbosity=minimal"` (1 failed, 5 passed)


------
https://chatgpt.com/codex/tasks/task_e_68b08b5673f48323b685beaa46266373