### PR TITLE
Use UTC timestamps for batch write logging

### DIFF
--- a/OctaneTagWritingTest/JobStrategies/JobStrategy3BatchSerializationPermalockStrategy.cs
+++ b/OctaneTagWritingTest/JobStrategies/JobStrategy3BatchSerializationPermalockStrategy.cs
@@ -98,7 +98,7 @@ namespace OctaneTagWritingTest.JobStrategies
                     var swWrite = writeTimers.GetOrAdd(tidHex, _ => new Stopwatch());
                     swWrite.Stop();
 
-                    var timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
+                    var timestamp = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss");
                     var oldEpc = writeResult.Tag.Epc.ToHexString();
                     var newEpc = TagOpController.Instance.GetExpectedEpc(tidHex);
                     var res = writeResult.Result.ToString();


### PR DESCRIPTION
## Summary
- use UTC timestamps for Job Strategy 3 write completion logging

## Testing
- `dotnet test OctaneTagWritingTest/OctaneTagWritingTest.sln` *(fails: 1 failed, 5 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b08dcf90348323b4df84f654458db0