### PR TITLE
Log ignored tag operation errors and preserve stack traces

### DIFF
--- a/OctaneTagWritingTest/Helpers/TagOpController.cs
+++ b/OctaneTagWritingTest/Helpers/TagOpController.cs
@@ -283,9 +283,9 @@ namespace OctaneTagWritingTest.Helpers
                 {
                     addedWriteSequences.TryAdd(seq.Id.ToString(), tag.Tid.ToHexString());
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
-
+                    Logger.Warning(ex, "Failed to track permalock sequence {SequenceId} for TID {TID}", seq.Id, tag.Tid.ToHexString());
                 }
 
                 CheckAndCleanAccessSequencesOnReader(addedWriteSequences, reader);
@@ -326,9 +326,9 @@ namespace OctaneTagWritingTest.Helpers
                 {
                     addedWriteSequences.TryAdd(seq.Id.ToString(), tag.Tid.ToHexString());
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
-
+                    Logger.Warning(ex, "Failed to track lock sequence {SequenceId} for TID {TID}", seq.Id, tag.Tid.ToHexString());
                 }
                 CheckAndCleanAccessSequencesOnReader(addedWriteSequences, reader);
 
@@ -439,8 +439,9 @@ namespace OctaneTagWritingTest.Helpers
             {
                 addedWriteSequences.TryAdd(seq.Id.ToString(), tag.Tid.ToHexString());
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                Logger.Warning(ex, "Failed to track write sequence {SequenceId} for TID {TID}", seq.Id, tag.Tid.ToHexString());
             }
 
             CheckAndCleanAccessSequencesOnReader(addedWriteSequences, reader);
@@ -532,9 +533,9 @@ namespace OctaneTagWritingTest.Helpers
             {
                 addedWriteSequences.TryAdd(seq.Id.ToString(), tag.Tid.ToHexString());
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-
+                Logger.Warning(ex, "Failed to track write sequence {SequenceId} for TID {TID}", seq.Id, tag.Tid.ToHexString());
             }
 
             CheckAndCleanAccessSequencesOnReader(addedWriteSequences, reader);
@@ -596,9 +597,9 @@ namespace OctaneTagWritingTest.Helpers
             {
                 addedReadSequences.TryAdd(seq.Id.ToString(), tag.Tid.ToHexString());
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-
+                Logger.Warning(ex, "Failed to track read sequence {SequenceId} for TID {TID}", seq.Id, tag.Tid.ToHexString());
             }
 
             CheckAndCleanAccessSequencesOnReader(addedReadSequences, reader);

--- a/OctaneTagWritingTest/JobStrategies/JobStrategy8MultipleReaderEnduranceStrategy.cs
+++ b/OctaneTagWritingTest/JobStrategies/JobStrategy8MultipleReaderEnduranceStrategy.cs
@@ -131,7 +131,7 @@ namespace OctaneTagWritingTest.JobStrategies
                     catch (Exception ex)
                     {
                         Console.WriteLine("ConfigureWriterReader - Error in dual reader endurance test: " + ex.Message);
-                        throw ex;
+                        throw;
                     }
                 }
 
@@ -144,7 +144,7 @@ namespace OctaneTagWritingTest.JobStrategies
                     catch (Exception ex)
                     {
                         Console.WriteLine("ConfigureVerifierReader - Error in dual reader endurance test: " + ex.Message);
-                        throw ex;
+                        throw;
                     }
                 }
 
@@ -175,7 +175,7 @@ namespace OctaneTagWritingTest.JobStrategies
                     catch (Exception ex)
                     {
                         Console.WriteLine("detectorReader - Error in dual reader endurance test: " + ex.Message);
-                        throw ex;
+                        throw;
                     }
                 }
 
@@ -188,7 +188,7 @@ namespace OctaneTagWritingTest.JobStrategies
                     catch (Exception ex)
                     {
                         Console.WriteLine("writerReader - Error in dual reader endurance test: " + ex.Message);
-                        throw ex;
+                        throw;
                     }
                 }
 
@@ -201,7 +201,7 @@ namespace OctaneTagWritingTest.JobStrategies
                     catch (Exception ex)
                     {
                         Console.WriteLine("verifierReader - Error in dual reader endurance test: " + ex.Message);
-                        throw ex;
+                        throw;
                     }
                 }
                 


### PR DESCRIPTION
## Summary
- warn when TagOpController fails to register tag operation sequences instead of silently swallowing errors
- rethrow exceptions without losing stack traces during multi-reader setup

## Testing
- `dotnet test OctaneTagWritingTest/OctaneTagWritingTest.sln` *(fails: FromSgtin96Hex_ShouldPreserveOriginalGTIN_WhenDecodedBack)*

------
https://chatgpt.com/codex/tasks/task_e_68b08edafd688323859c111da7297605