### PR TITLE
Log ignored exceptions in EPC generator

### DIFF
--- a/EpcListGenerator/EpcListGeneratorHelper.cs
+++ b/EpcListGenerator/EpcListGeneratorHelper.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography;
 using Impinj.TagUtils;
 using OctaneTagWritingTest.Helpers;
 using TagDataTranslation;
+using Serilog;
 
 namespace EpcListGenerator
 {
@@ -14,6 +15,7 @@ namespace EpcListGenerator
     public sealed class EpcListGeneratorHelper
     {
         private static readonly TDTEngine _tdtEngine = new();
+        private static readonly ILogger Logger = Log.ForContext<EpcListGeneratorHelper>();
 
         // Lazy initialization of the singleton instance (thread-safe).
         private static readonly Lazy<EpcListGeneratorHelper> instance =
@@ -62,17 +64,16 @@ namespace EpcListGenerator
             {
                 try
                 {
-                    string epcIdentifier = @"gtin=" + gtin + ";serial="+i;
+                    string epcIdentifier = @"gtin=" + gtin + ";serial=" + i;
                     string parameterList = @"filter=1;gs1companyprefixlength=6;tagLength=96";
                     string binary = _tdtEngine.Translate(epcIdentifier, parameterList, @"BINARY");
                     string sgtinHex = _tdtEngine.BinaryToHex(binary);
 
                     epcList.Add(sgtinHex.ToUpper());
-
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
-
+                    Logger.Warning(ex, "Failed to generate EPC for GTIN {GTIN} with serial {Serial}", gtin, i);
                 }
             }
 


### PR DESCRIPTION
## Summary
- capture and log translation errors when generating EPCs
- wire up Serilog logger in EpcListGeneratorHelper

## Testing
- `dotnet test TagUtils.Tests/TagUtils.Tests.csproj` *(fails: FromSgtin96Hex_ShouldPreserveOriginalGTIN_WhenDecodedBack)*

------
https://chatgpt.com/codex/tasks/task_e_68b094be26e88323b5e775c6c57bc794