### PR TITLE
feat: add reader abstraction and epc error logging

### DIFF
--- a/OctaneTagWritingTest/BaseTestStrategy.cs
+++ b/OctaneTagWritingTest/BaseTestStrategy.cs
@@ -1,5 +1,6 @@
 ﻿using Impinj.OctaneSdk;
 using OctaneTagWritingTest.Helpers;
+using OctaneTagWritingTest.Infrastructure;
 using Org.LLRP.LTK.LLRPV1;
 using Org.LLRP.LTK.LLRPV1.Impinj;
 using System;
@@ -16,7 +17,7 @@ namespace OctaneTagWritingTest
     /// </summary>
     public abstract class BaseTestStrategy : IJobStrategy
     {
-        protected ImpinjReader reader;
+        protected IReaderClient reader;
         protected string hostname;
         protected string newAccessPassword = "00000000";
         protected string targetTid;  // Will be set with first TID read
@@ -32,11 +33,12 @@ namespace OctaneTagWritingTest
         /// <param name="hostname">The hostname of the RFID reader</param>
         /// <param name="logFile">The path to the log file for test results</param>
         /// <param name="readerSettings">Dictionary of reader settings by role</param>
-        public BaseTestStrategy(string hostname, string logFile, Dictionary<string, ReaderSettings> readerSettings)
+        /// <param name="readerClient">Optional reader client for dependency injection</param>
+        public BaseTestStrategy(string hostname, string logFile, Dictionary<string, ReaderSettings> readerSettings, IReaderClient readerClient = null)
         {
             this.hostname = hostname;
             this.logFile = logFile;
-            reader = new ImpinjReader();
+            reader = readerClient ?? new ImpinjReaderClient();
             this.settings = readerSettings;
         }
 

--- a/OctaneTagWritingTest/Helpers/EpcListManager.cs
+++ b/OctaneTagWritingTest/Helpers/EpcListManager.cs
@@ -7,10 +7,13 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using TagDataTranslation;
+using Serilog;
+using OctaneTagWritingTest;
 
 public sealed class EpcListManager
 {
     private static readonly TDTEngine _tdtEngine = new();
+    private static readonly ILogger Logger = LoggingConfiguration.CreateLogger<EpcListManager>();
 
     // Singleton instance with lazy initialization (thread-safe)
     private static readonly Lazy<EpcListManager> instance =
@@ -111,9 +114,9 @@ public sealed class EpcListManager
                     //epcPrefix = emptySgtin.ToEpc().Substring(0, 14);
 
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
-
+                    Logger.Warning(ex, "Failed to generate EPC for GTIN {GTIN} from TID {TID}", gtin, tid);
                 }
             }
             else

--- a/OctaneTagWritingTest/Helpers/TagOpController.cs
+++ b/OctaneTagWritingTest/Helpers/TagOpController.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Serilog;
+using OctaneTagWritingTest.Infrastructure;
 
 namespace OctaneTagWritingTest.Helpers
 {
@@ -252,7 +253,7 @@ namespace OctaneTagWritingTest.Helpers
             }
         }
 
-        public void PermaLockTag(Tag tag, string accessPassword, ImpinjReader reader)
+        public void PermaLockTag(Tag tag, string accessPassword, IReaderClient reader)
         {
             try
             {
@@ -299,7 +300,7 @@ namespace OctaneTagWritingTest.Helpers
             }
         }
 
-        public void LockTag(Tag tag, string accessPassword, ImpinjReader reader)
+        public void LockTag(Tag tag, string accessPassword, IReaderClient reader)
         {
             try
             {
@@ -341,7 +342,7 @@ namespace OctaneTagWritingTest.Helpers
             }
         }
 
-        public void CheckAndCleanAccessSequencesOnReader(ConcurrentDictionary<string, string> addedSequences, ImpinjReader reader)
+        public void CheckAndCleanAccessSequencesOnReader(ConcurrentDictionary<string, string> addedSequences, IReaderClient reader)
         {
             try
             {
@@ -375,7 +376,7 @@ namespace OctaneTagWritingTest.Helpers
         /// <param name="targetAntennaPort">Target antenna port (default 1)</param>
         /// <param name="useBlockWrite">Whether to use block write operations (default true)</param>
         /// <param name="sequenceMaxRetries">Maximum number of retries for the sequence (default 5)</param>
-        public void TriggerPartialWriteAndVerify(Tag tag, string newEpcToWrite, ImpinjReader reader, CancellationToken cancellationToken, Stopwatch swWrite, string newAccessPassword, bool encodeOrDefault, int charactersToWrite = 14, ushort targetAntennaPort = 1, bool useBlockWrite = true, ushort sequenceMaxRetries = 5)
+        public void TriggerPartialWriteAndVerify(Tag tag, string newEpcToWrite, IReaderClient reader, CancellationToken cancellationToken, Stopwatch swWrite, string newAccessPassword, bool encodeOrDefault, int charactersToWrite = 14, ushort targetAntennaPort = 1, bool useBlockWrite = true, ushort sequenceMaxRetries = 5)
         {
             if (cancellationToken.IsCancellationRequested) return;
 
@@ -472,7 +473,7 @@ namespace OctaneTagWritingTest.Helpers
             RecordExpectedEpc(currentTid, epcData);
         }
 
-        public void TriggerWriteAndVerify(Tag tag, string newEpcToWrite, ImpinjReader reader, CancellationToken cancellationToken, Stopwatch swWrite, string newAccessPassword, bool encodeOrDefault, ushort targetAntennaPort = 1, bool useBlockWrite = true, ushort sequenceMaxRetries = 5)
+        public void TriggerWriteAndVerify(Tag tag, string newEpcToWrite, IReaderClient reader, CancellationToken cancellationToken, Stopwatch swWrite, string newAccessPassword, bool encodeOrDefault, ushort targetAntennaPort = 1, bool useBlockWrite = true, ushort sequenceMaxRetries = 5)
         {
             if (cancellationToken.IsCancellationRequested) return;
 
@@ -568,7 +569,7 @@ namespace OctaneTagWritingTest.Helpers
             RecordExpectedEpc(currentTid, epcData);
         }
 
-        public void TriggerVerificationRead(Tag tag, ImpinjReader reader, CancellationToken cancellationToken, Stopwatch swVerify, string newAccessPassword)
+        public void TriggerVerificationRead(Tag tag, IReaderClient reader, CancellationToken cancellationToken, Stopwatch swVerify, string newAccessPassword)
         {
             if (cancellationToken.IsCancellationRequested) return;
 
@@ -686,7 +687,7 @@ namespace OctaneTagWritingTest.Helpers
             }
         }
 
-        public void ProcessVerificationResult(TagReadOpResult readResult, string tidHex, ConcurrentDictionary<string, int> recoveryCount, Stopwatch swWrite, Stopwatch swVerify, string logFile, ImpinjReader reader, CancellationToken cancellationToken, string newAccessPassword, int maxRecoveryAttempts)
+        public void ProcessVerificationResult(TagReadOpResult readResult, string tidHex, ConcurrentDictionary<string, int> recoveryCount, Stopwatch swWrite, Stopwatch swVerify, string logFile, IReaderClient reader, CancellationToken cancellationToken, string newAccessPassword, int maxRecoveryAttempts)
         {
             swVerify.Stop();
 

--- a/OctaneTagWritingTest/Infrastructure/IReaderClient.cs
+++ b/OctaneTagWritingTest/Infrastructure/IReaderClient.cs
@@ -1,0 +1,30 @@
+using Impinj.OctaneSdk;
+using Org.LLRP.LTK.LLRPV1;
+using Org.LLRP.LTK.LLRPV1.Impinj;
+
+namespace OctaneTagWritingTest.Infrastructure
+{
+    /// <summary>
+    /// Abstraction for Impinj reader interactions enabling test mocking.
+    /// </summary>
+    public interface IReaderClient
+    {
+        event TagsReportedEventHandler TagsReported;
+        event TagOpCompleteEventHandler TagOpComplete;
+        event GpiEventHandler GpiChanged;
+
+        void Connect(string hostname);
+        void ApplyDefaultSettings();
+        Settings QueryDefaultSettings();
+        MSG_ADD_ROSPEC BuildAddROSpecMessage(Settings settings);
+        MSG_SET_READER_CONFIG BuildSetReaderConfigMessage(Settings settings);
+        void ApplySettings(Settings settings);
+        void ApplySettings(MSG_SET_READER_CONFIG setConfig, MSG_ADD_ROSPEC addRospec);
+        void Start();
+        void Stop();
+        void Disconnect();
+        void AddOpSequence(TagOpSequence sequence);
+        void DeleteAllOpSequences();
+        bool IsConnected { get; }
+    }
+}

--- a/OctaneTagWritingTest/Infrastructure/ImpinjReaderClient.cs
+++ b/OctaneTagWritingTest/Infrastructure/ImpinjReaderClient.cs
@@ -1,0 +1,58 @@
+using Impinj.OctaneSdk;
+using Org.LLRP.LTK.LLRPV1;
+using Org.LLRP.LTK.LLRPV1.Impinj;
+
+namespace OctaneTagWritingTest.Infrastructure
+{
+    /// <summary>
+    /// Default implementation of <see cref="IReaderClient"/> that wraps an <see cref="ImpinjReader"/>.
+    /// </summary>
+    public class ImpinjReaderClient : IReaderClient
+    {
+        private readonly ImpinjReader _reader = new();
+
+        public event TagsReportedEventHandler TagsReported
+        {
+            add { _reader.TagsReported += value; }
+            remove { _reader.TagsReported -= value; }
+        }
+
+        public event TagOpCompleteEventHandler TagOpComplete
+        {
+            add { _reader.TagOpComplete += value; }
+            remove { _reader.TagOpComplete -= value; }
+        }
+
+        public event GpiEventHandler GpiChanged
+        {
+            add { _reader.GpiChanged += value; }
+            remove { _reader.GpiChanged -= value; }
+        }
+
+        public void Connect(string hostname) => _reader.Connect(hostname);
+
+        public void ApplyDefaultSettings() => _reader.ApplyDefaultSettings();
+
+        public Settings QueryDefaultSettings() => _reader.QueryDefaultSettings();
+
+        public MSG_ADD_ROSPEC BuildAddROSpecMessage(Settings settings) => _reader.BuildAddROSpecMessage(settings);
+
+        public MSG_SET_READER_CONFIG BuildSetReaderConfigMessage(Settings settings) => _reader.BuildSetReaderConfigMessage(settings);
+
+        public void ApplySettings(Settings settings) => _reader.ApplySettings(settings);
+
+        public void ApplySettings(MSG_SET_READER_CONFIG setConfig, MSG_ADD_ROSPEC addRospec) => _reader.ApplySettings(setConfig, addRospec);
+
+        public void Start() => _reader.Start();
+
+        public void Stop() => _reader.Stop();
+
+        public void Disconnect() => _reader.Disconnect();
+
+        public void AddOpSequence(TagOpSequence sequence) => _reader.AddOpSequence(sequence);
+
+        public void DeleteAllOpSequences() => _reader.DeleteAllOpSequences();
+
+        public bool IsConnected => _reader.IsConnected;
+    }
+}

--- a/OctaneTagWritingTest/JobStrategies/JobStrategy8MultipleReaderEnduranceStrategy.cs
+++ b/OctaneTagWritingTest/JobStrategies/JobStrategy8MultipleReaderEnduranceStrategy.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Impinj.OctaneSdk;
 using OctaneTagWritingTest.Helpers;
 using Org.LLRP.LTK.LLRPV1.Impinj;
+using OctaneTagWritingTest.Infrastructure;
 
 namespace OctaneTagWritingTest.JobStrategies
 {
@@ -28,10 +29,10 @@ namespace OctaneTagWritingTest.JobStrategies
         private readonly ConcurrentDictionary<string, Stopwatch> swWriteTimers = new ConcurrentDictionary<string, Stopwatch>();
         private readonly ConcurrentDictionary<string, Stopwatch> swVerifyTimers = new ConcurrentDictionary<string, Stopwatch>();
 
-        private ImpinjReader detectorReader;
+        private IReaderClient detectorReader;
         // Two separate readers: one for writing and one for verifying.
-        private ImpinjReader writerReader;
-        private ImpinjReader verifierReader;
+        private IReaderClient writerReader;
+        private IReaderClient verifierReader;
         private string detectorAddress;
         private string writerAddress;
         private string verifierAddress;
@@ -77,9 +78,9 @@ namespace OctaneTagWritingTest.JobStrategies
             gpoPortStatic = (ushort)appConfig.GpoPortStatic;
 
 
-            detectorReader = new ImpinjReader();
-            writerReader = new ImpinjReader();
-            verifierReader = new ImpinjReader();
+            detectorReader = new ImpinjReaderClient();
+            writerReader = new ImpinjReaderClient();
+            verifierReader = new ImpinjReaderClient();
 
             // Clean up any previous tag operation state.
             TagOpController.Instance.CleanUp();
@@ -354,7 +355,7 @@ namespace OctaneTagWritingTest.JobStrategies
             verifierReader.ApplySettings(verifierSettings);
         }
 
-        private void EnableLowLatencyReporting(Settings settings, ImpinjReader reader)
+        private void EnableLowLatencyReporting(Settings settings, IReaderClient reader)
         {
             var addRoSpecMessage = reader.BuildAddROSpecMessage(settings);
             var setReaderConfigMessage = reader.BuildSetReaderConfigMessage(settings);
@@ -365,7 +366,7 @@ namespace OctaneTagWritingTest.JobStrategies
             reader.ApplySettings(setReaderConfigMessage, addRoSpecMessage);
         }
 
-        private ImpinjReader SelectWriterReader()
+        private IReaderClient SelectWriterReader()
         {
             if (writerReader != null && writerReader.IsConnected)
                 return writerReader;

--- a/OctaneTagWritingTest/JobStrategies/JobStrategy9CheckBox.cs
+++ b/OctaneTagWritingTest/JobStrategies/JobStrategy9CheckBox.cs
@@ -10,6 +10,7 @@ using Impinj.OctaneSdk;
 using OctaneTagWritingTest.Helpers;
 using Org.LLRP.LTK.LLRPV1.Impinj;
 using Serilog;
+using OctaneTagWritingTest.Infrastructure;
 
 namespace OctaneTagWritingTest.JobStrategies
 {
@@ -24,7 +25,7 @@ namespace OctaneTagWritingTest.JobStrategies
     public class JobStrategy9CheckBox : BaseTestStrategy
     {
         private static readonly ILogger Logger = LoggingConfiguration.CreateStrategyLogger("CheckBoxStrategy");
-        private ImpinjReader writerReader;
+        private IReaderClient writerReader;
         // Duration for tag collection (in seconds)
         private const int ReadDurationSeconds = 10;
         // Overall timeout for write operations (in seconds)
@@ -115,7 +116,7 @@ namespace OctaneTagWritingTest.JobStrategies
         {
             var writerSettings = GetSettingsForRole("writer");
             if(writerReader == null)
-                writerReader = new ImpinjReader();
+                writerReader = new ImpinjReaderClient();
 
             if(!writerReader.IsConnected)
             {
@@ -166,7 +167,7 @@ namespace OctaneTagWritingTest.JobStrategies
 
         }
 
-        private void EnableLowLatencyReporting(Settings settings, ImpinjReader reader)
+        private void EnableLowLatencyReporting(Settings settings, IReaderClient reader)
         {
             var addRoSpecMessage = reader.BuildAddROSpecMessage(settings);
             var setReaderConfigMessage = reader.BuildSetReaderConfigMessage(settings);


### PR DESCRIPTION
## Summary
- add Serilog warning to EPC generation when translation fails
- introduce IReaderClient interface with ImpinjReaderClient implementation
- refactor strategies and tag operations to depend on reader abstraction

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b096bbd780832393ab44a2770bf0e6