### PR TITLE
Fix reader type for tag operations

### DIFF
--- a/OctaneTagWritingTest/JobStrategies/JobStrategy8MultipleReaderEnduranceStrategy.cs
+++ b/OctaneTagWritingTest/JobStrategies/JobStrategy8MultipleReaderEnduranceStrategy.cs
@@ -521,11 +521,11 @@ namespace OctaneTagWritingTest.JobStrategies
                     TagOpController.Instance.TriggerWriteAndVerify(
                         tag,
                         expectedEpc,
-                        sender,
+                        writerReader,
                         cancellationToken,
                         swWriteTimers.GetOrAdd(tidHex, _ => new Stopwatch()),
                         newAccessPassword,
-                        true, 
+                        true,
                         1,
                         true,
                         3);
@@ -673,10 +673,10 @@ namespace OctaneTagWritingTest.JobStrategies
                     {
                         Console.WriteLine($"OnTagOpComplete - Write operation succeeded for TID {tidHex} on reader {sender.Name}.");
                         // After a successful write, trigger a verification read on the verifier reader.
-                        
+
                         TagOpController.Instance.TriggerVerificationRead(
                             result.Tag,
-                            sender,
+                            verifierReader,
                             cancellationToken,
                             swVerifyTimers.GetOrAdd(tidHex, _ => new Stopwatch()),
                             newAccessPassword);


### PR DESCRIPTION
## Summary
- ensure write operations use `IReaderClient` instead of `ImpinjReader`
- trigger verification reads on `verifierReader` to match interface

## Testing
- `dotnet test OctaneTagWritingTest/OctaneTagWritingTest.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b0b1b7117883238ad0cff778881c98