### PR TITLE
Fix TagOpComplete handler delegate

### DIFF
--- a/OctaneTagWritingTest/Infrastructure/IReaderClient.cs
+++ b/OctaneTagWritingTest/Infrastructure/IReaderClient.cs
@@ -10,7 +10,7 @@ namespace OctaneTagWritingTest.Infrastructure
     public interface IReaderClient
     {
         event TagsReportedEventHandler TagsReported;
-        event TagOpCompleteEventHandler TagOpComplete;
+        event ImpinjReader.TagOpCompleteHandler TagOpComplete;
         event GpiEventHandler GpiChanged;
 
         void Connect(string hostname);

--- a/OctaneTagWritingTest/Infrastructure/ImpinjReaderClient.cs
+++ b/OctaneTagWritingTest/Infrastructure/ImpinjReaderClient.cs
@@ -17,7 +17,7 @@ namespace OctaneTagWritingTest.Infrastructure
             remove { _reader.TagsReported -= value; }
         }
 
-        public event TagOpCompleteEventHandler TagOpComplete
+        public event ImpinjReader.TagOpCompleteHandler TagOpComplete
         {
             add { _reader.TagOpComplete += value; }
             remove { _reader.TagOpComplete -= value; }


### PR DESCRIPTION
## Summary
- use `ImpinjReader.TagOpCompleteHandler` for TagOpComplete event to match SDK

## Testing
- `dotnet test OctaneTagWritingTest/OctaneTagWritingTest.sln`

------
https://chatgpt.com/codex/tasks/task_e_68b0b320ff448323b996018275900273