### PR TITLE
Optimize NumberRange parsing

### DIFF
--- a/TagUtils/TagUtils/NumberRange.cs
+++ b/TagUtils/TagUtils/NumberRange.cs
@@ -23,7 +23,7 @@ namespace Impinj.TagUtils
         {
             if (string.IsNullOrWhiteSpace(strNumberRange))
                 return new NumberRange();
-            string[] strArray = strNumberRange.Trim().Split("-".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
+            string[] strArray = strNumberRange.Trim().Split('-', StringSplitOptions.RemoveEmptyEntries);
             if (strArray.Length < 1 || strArray.Length > 2)
             {
                 DefaultInterpolatedStringHandler interpolatedStringHandler = new DefaultInterpolatedStringHandler(71, 1);
@@ -31,7 +31,8 @@ namespace Impinj.TagUtils
                 interpolatedStringHandler.AppendLiteral(" Range values specified which is more than the 2 that were anticipated!");
                 throw new InvalidCastException(interpolatedStringHandler.ToStringAndClear());
             }
-            return 1 == strArray.Length ? new NumberRange(strArray[0].ToInt64()) : new NumberRange(strArray[0].ToInt64(), strArray[1].ToInt64());
+            long first = strArray[0].ToInt64();
+            return strArray.Length == 1 ? new NumberRange(first) : new NumberRange(first, strArray[1].ToInt64());
         }
 
         public string ToHexString()


### PR DESCRIPTION
## Summary
- avoid allocating char array when splitting number range strings
- parse first range value once and reuse when possible

## Testing
- `dotnet test TagUtils.Tests/TagUtils.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c03b9366dc8323b180c7090e320c75