### PR TITLE
Add immutable LogEvent record with CsvPayload support

### DIFF
--- a/Common/Logging/LogEvent.cs
+++ b/Common/Logging/LogEvent.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace Common.Logging;
+
+[Serializable]
+public enum LogLevel
+{
+    Trace,
+    Debug,
+    Information,
+    Warning,
+    Error,
+    Critical
+}
+
+[Serializable]
+public readonly record struct CsvPayload(string FilePath, string Header, string Line);
+
+[Serializable]
+public record LogEvent
+{
+    public DateTime Timestamp { get; init; }
+    public LogLevel Level { get; init; }
+    public string MessageTemplate { get; init; }
+    public object[]? Parameters { get; init; }
+    public CsvPayload? CsvPayload { get; init; }
+
+    public LogEvent(DateTime timestamp, LogLevel level, string messageTemplate, object[]? parameters = null, CsvPayload? csvPayload = null)
+    {
+        Timestamp = timestamp;
+        Level = level;
+        MessageTemplate = messageTemplate;
+        Parameters = parameters is null ? null : (object[])parameters.Clone();
+        CsvPayload = csvPayload;
+    }
+}


### PR DESCRIPTION
## Summary
- add `LogLevel` enum and `CsvPayload` record struct
- introduce serializable, immutable `LogEvent` for thread-safe logging

## Testing
- `dotnet test TagUtils.Tests/TagUtils.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c05678e6608323a1d533e1f2793e3b