### PR TITLE
Add logging sinks and update service

### DIFF
--- a/Common/Logging/LoggingService.cs
+++ b/Common/Logging/LoggingService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
+using Common.Logging.Sinks;
 
 namespace Common.Logging;
 
@@ -42,12 +43,12 @@ public sealed class LoggingService : IDisposable, IAsyncDisposable
         _consumerTask = Task.Run(async () =>
         {
             await foreach (var logEvent in _channel.Reader.ReadAllAsync(_cts.Token))
-            {
-                foreach (var sink in _sinks)
-                {
-                    await sink.WriteAsync(logEvent).ConfigureAwait(false);
-                }
-            }
+              {
+                  foreach (var sink in _sinks)
+                  {
+                      sink.Write(logEvent);
+                  }
+              }
         }, _cts.Token);
     }
 
@@ -72,22 +73,38 @@ public sealed class LoggingService : IDisposable, IAsyncDisposable
     public void LogError(string template, params object[] args) => Log(LogLevel.Error, template, args);
     public void LogCritical(string template, params object[] args) => Log(LogLevel.Critical, template, args);
 
-    /// <summary>
-    /// Flushes all queued log events and waits for the consumer to finish.
-    /// </summary>
-    public async Task FlushAsync()
-    {
-        if (_channel is null)
-        {
-            return;
-        }
+      /// <summary>
+      /// Flushes all queued log events and waits for the consumer to finish.
+      /// </summary>
+      public async Task FlushAsync()
+      {
+          if (_channel is null)
+          {
+              return;
+          }
 
-        _channel.Writer.Complete();
-        if (_consumerTask is not null)
-        {
-            await _consumerTask.ConfigureAwait(false);
-        }
-    }
+          _channel.Writer.Complete();
+          if (_consumerTask is not null)
+          {
+              await _consumerTask.ConfigureAwait(false);
+          }
+
+          if (_sinks is not null)
+          {
+              foreach (var sink in _sinks)
+              {
+                  switch (sink)
+                  {
+                      case IAsyncDisposable asyncDisposable:
+                          await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+                          break;
+                      case IDisposable disposable:
+                          disposable.Dispose();
+                          break;
+                  }
+              }
+          }
+      }
 
     /// <summary>
     /// Stops the logging service and flushes any remaining events.
@@ -107,14 +124,6 @@ public sealed class LoggingService : IDisposable, IAsyncDisposable
         await FlushAsync().ConfigureAwait(false);
         _cts?.Dispose();
     }
-}
-
-/// <summary>
-/// Represents a destination that log events can be written to.
-/// </summary>
-public interface ILogSink
-{
-    ValueTask WriteAsync(LogEvent logEvent);
 }
 
 /// <summary>

--- a/Common/Logging/Sinks/CsvSink.cs
+++ b/Common/Logging/Sinks/CsvSink.cs
@@ -1,0 +1,65 @@
+using System.Collections.Concurrent;
+using System.Text;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using System.IO;
+using Common.Logging;
+
+namespace Common.Logging.Sinks;
+
+/// <summary>
+/// Batches CSV log events by file and writes them asynchronously.
+/// </summary>
+public sealed class CsvSink : ILogSink, IAsyncDisposable, IDisposable
+{
+    private readonly ConcurrentDictionary<string, Channel<CsvPayload>> _channels = new();
+    private readonly ConcurrentDictionary<string, Task> _tasks = new();
+
+    public void Write(LogEvent evt)
+    {
+        if (evt.CsvPayload is not { } payload)
+        {
+            return;
+        }
+
+        var channel = _channels.GetOrAdd(payload.FilePath, path =>
+        {
+            var ch = Channel.CreateUnbounded<CsvPayload>();
+            var task = Task.Run(() => ProcessChannel(path, ch));
+            _tasks[path] = task;
+            return ch;
+        });
+
+        channel.Writer.TryWrite(payload);
+    }
+
+    private static async Task ProcessChannel(string path, Channel<CsvPayload> channel)
+    {
+        var exists = File.Exists(path);
+        await using var stream = new StreamWriter(path, append: true, Encoding.UTF8);
+        await foreach (var payload in channel.Reader.ReadAllAsync())
+        {
+            if (!exists)
+            {
+                await stream.WriteLineAsync(payload.Header);
+                exists = true;
+            }
+            await stream.WriteLineAsync(payload.Line);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var channel in _channels.Values)
+        {
+            channel.Writer.Complete();
+        }
+
+        if (_tasks.Count > 0)
+        {
+            await Task.WhenAll(_tasks.Values).ConfigureAwait(false);
+        }
+    }
+
+    public void Dispose() => DisposeAsync().AsTask().GetAwaiter().GetResult();
+}

--- a/Common/Logging/Sinks/ILogSink.cs
+++ b/Common/Logging/Sinks/ILogSink.cs
@@ -1,0 +1,8 @@
+using Common.Logging;
+
+namespace Common.Logging.Sinks;
+
+public interface ILogSink
+{
+    void Write(LogEvent evt);
+}

--- a/Common/Logging/Sinks/SerilogSink.cs
+++ b/Common/Logging/Sinks/SerilogSink.cs
@@ -1,0 +1,32 @@
+using Serilog;
+using Serilog.Events;
+using LogEvent = Common.Logging.LogEvent;
+using LogLevel = Common.Logging.LogLevel;
+
+namespace Common.Logging.Sinks;
+
+public sealed class SerilogSink : ILogSink
+{
+    public void Write(LogEvent evt)
+    {
+        var level = evt.Level switch
+        {
+            LogLevel.Trace => LogEventLevel.Verbose,
+            LogLevel.Debug => LogEventLevel.Debug,
+            LogLevel.Information => LogEventLevel.Information,
+            LogLevel.Warning => LogEventLevel.Warning,
+            LogLevel.Error => LogEventLevel.Error,
+            LogLevel.Critical => LogEventLevel.Fatal,
+            _ => LogEventLevel.Information
+        };
+
+        if (evt.Parameters is { Length: > 0 })
+        {
+            Log.Write(level, evt.MessageTemplate, evt.Parameters);
+        }
+        else
+        {
+            Log.Write(level, evt.MessageTemplate);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `ILogSink` interface for log destinations
- add Serilog and CSV sink implementations
- update logging service to use sinks and dispose them on flush

## Testing
- `dotnet test TagUtils.Tests/TagUtils.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c05955520083238e823c833199c061