### PR TITLE
Start logging service with Serilog and CSV sinks

### DIFF
--- a/OctaneTagWritingTest/LoggingConfiguration.cs
+++ b/OctaneTagWritingTest/LoggingConfiguration.cs
@@ -1,6 +1,8 @@
 using Serilog;
 using Serilog.Events;
 using Serilog.Formatting.Compact;
+using Common.Logging;
+using Common.Logging.Sinks;
 
 namespace OctaneTagWritingTest
 {
@@ -39,7 +41,13 @@ namespace OctaneTagWritingTest
                     shared: true)
                 .CreateLogger();
 
-            Log.Information("Logging configured for {Application} with test description: {TestDescription}", 
+            var serilogSink = new SerilogSink();
+            var csvSink = new CsvSink();
+            var sinks = new ILogSink[] { serilogSink, csvSink };
+            var config = new Common.Logging.LoggingConfiguration(sinks);
+            LoggingService.Instance.Start(config);
+
+            Log.Information("Logging configured for {Application} with test description: {TestDescription}",
                 "OctaneTagWritingTest", testDescription);
         }
 
@@ -112,6 +120,7 @@ namespace OctaneTagWritingTest
         /// </summary>
         public static void CloseAndFlush()
         {
+            LoggingService.Instance.Stop();
             Log.CloseAndFlush();
         }
     }

--- a/OctaneTagWritingTest/OctaneTagWritingTest.csproj
+++ b/OctaneTagWritingTest/OctaneTagWritingTest.csproj
@@ -21,6 +21,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Common\**\*.cs" Link="Common\%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Folder Include="etk_deploy\" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- start logging service with Serilog and CSV sinks
- ensure logging service stops on application shutdown
- include shared logging sources in build

## Testing
- `dotnet build OctaneTagWritingTest/OctaneTagWritingTest.csproj`
- `dotnet test OctaneTagWritingTest/OctaneTagWritingTest.sln`


------
https://chatgpt.com/codex/tasks/task_e_68c05bee208c83238d63a55f874875d1