### PR TITLE
feat: add CSV logging via LoggingService

### DIFF
--- a/Common/Logging/LoggingService.cs
+++ b/Common/Logging/LoggingService.cs
@@ -66,6 +66,24 @@ public sealed class LoggingService : IDisposable, IAsyncDisposable
         _channel.Writer.TryWrite(logEvent);
     }
 
+    /// <summary>
+    /// Enqueues a CSV log event for asynchronous processing.
+    /// </summary>
+    /// <param name="file">Destination CSV file path.</param>
+    /// <param name="header">CSV header to ensure is written once per file.</param>
+    /// <param name="line">CSV data line to append.</param>
+    public void LogCsv(string file, string header, string line)
+    {
+        if (_channel is null)
+        {
+            throw new InvalidOperationException("LoggingService has not been started.");
+        }
+
+        var logEvent = new LogEvent(DateTime.UtcNow, LogLevel.Information, string.Empty, null,
+            new CsvPayload(file, header, line));
+        _channel.Writer.TryWrite(logEvent);
+    }
+
     public void LogTrace(string template, params object[] args) => Log(LogLevel.Trace, template, args);
     public void LogDebug(string template, params object[] args) => Log(LogLevel.Debug, template, args);
     public void LogInfo(string template, params object[] args) => Log(LogLevel.Information, template, args);

--- a/Common/Logging/Sinks/CsvSink.cs
+++ b/Common/Logging/Sinks/CsvSink.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Text;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -35,8 +36,16 @@ public sealed class CsvSink : ILogSink, IAsyncDisposable, IDisposable
 
     private static async Task ProcessChannel(string path, Channel<CsvPayload> channel)
     {
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
         var exists = File.Exists(path);
         await using var stream = new StreamWriter(path, append: true, Encoding.UTF8);
+        var batch = new List<string>(64);
+
         await foreach (var payload in channel.Reader.ReadAllAsync())
         {
             if (!exists)
@@ -44,7 +53,26 @@ public sealed class CsvSink : ILogSink, IAsyncDisposable, IDisposable
                 await stream.WriteLineAsync(payload.Header);
                 exists = true;
             }
-            await stream.WriteLineAsync(payload.Line);
+
+            batch.Add(payload.Line);
+            if (batch.Count >= 50)
+            {
+                foreach (var line in batch)
+                {
+                    await stream.WriteLineAsync(line);
+                }
+                await stream.FlushAsync();
+                batch.Clear();
+            }
+        }
+
+        if (batch.Count > 0)
+        {
+            foreach (var line in batch)
+            {
+                await stream.WriteLineAsync(line);
+            }
+            await stream.FlushAsync();
         }
     }
 

--- a/OctaneTagWritingTest/BaseTestStrategy.cs
+++ b/OctaneTagWritingTest/BaseTestStrategy.cs
@@ -85,7 +85,7 @@ namespace OctaneTagWritingTest
         /// <param name="line">The line to append to the log file</param>
         protected void LogToCsv(string line)
         {
-            File.AppendAllText(logFile, line + Environment.NewLine);
+            TagOpController.Instance.LogToCsv(logFile, line);
         }
 
         /// <summary>

--- a/OctaneTagWritingTest/Helpers/TagOpController.cs
+++ b/OctaneTagWritingTest/Helpers/TagOpController.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Serilog;
+using Common.Logging;
 using OctaneTagWritingTest.Infrastructure;
 
 namespace OctaneTagWritingTest.Helpers
@@ -72,7 +73,7 @@ namespace OctaneTagWritingTest.Helpers
         public string LocalTargetTid { get; private set; } = string.Empty;
         public bool IsLocalTargetTidSet { get; private set; }
 
-        private readonly object fileLock = new object();
+        private readonly ConcurrentDictionary<string, string> csvHeaders = new();
 
         public void CleanUp()
         {
@@ -670,21 +671,26 @@ namespace OctaneTagWritingTest.Helpers
         }
 
         /// <summary>
-        /// Appends a line to the CSV log file
+        /// Appends a line to the CSV log file. The first call for a given file is
+        /// treated as the header and will not produce a log entry.
         /// </summary>
         /// <param name="line">The line to append to the log file</param>
         public void LogToCsv(string logFile, string line)
         {
             try
             {
-                lock (fileLock)
+                if (csvHeaders.TryAdd(logFile, line))
                 {
-                    File.AppendAllText(logFile, line + Environment.NewLine);
+                    // First call sets the header without logging a line.
+                    return;
                 }
+
+                var header = csvHeaders[logFile];
+                LoggingService.Instance.LogCsv(logFile, header, line);
             }
             catch (Exception ex)
             {
-                logger.Warning(ex, "Unable to write data to CSV log file {LogFile}", logFile);
+                logger.Warning(ex, "Unable to enqueue data to CSV log file {LogFile}", logFile);
             }
         }
 

--- a/OctaneTagWritingTest/JobStrategies/JobStrategy0ReadOnlyLogging.cs
+++ b/OctaneTagWritingTest/JobStrategies/JobStrategy0ReadOnlyLogging.cs
@@ -80,10 +80,7 @@ namespace OctaneTagWritingTest.JobStrategies
 
         private new void LogToCsv(string data)
         {
-            lock (this)
-            {
-                File.AppendAllText(logFile, data + Environment.NewLine);
-            }
+            TagOpController.Instance.LogToCsv(logFile, data);
         }
 
         


### PR DESCRIPTION
## Summary
- add LogCsv helper to LoggingService
- route all job strategy CSV writes through LoggingService
- batch CSV output and ensure headers/directories in CsvSink

## Testing
- `dotnet test TagUtils.Tests/TagUtils.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68c07417fac88323b1a79f9b0f70adf2