### PR TITLE
Use LoggingService context helpers

### DIFF
--- a/Common/Logging/ContextLogger.cs
+++ b/Common/Logging/ContextLogger.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+
+namespace Common.Logging;
+
+internal sealed class ContextLogger : ILogger
+{
+    private readonly LoggingService _service;
+    private readonly IReadOnlyList<(string Key, object Value)> _context;
+
+    public ContextLogger(LoggingService service, IReadOnlyList<(string Key, object Value)> context)
+    {
+        _service = service;
+        _context = context;
+    }
+
+    private void Log(LogLevel level, string messageTemplate, Exception? exception, object[] args)
+    {
+        _service.Log(level, messageTemplate, args, exception, _context);
+    }
+
+    public void Debug(string messageTemplate, params object[] args) => Log(LogLevel.Debug, messageTemplate, null, args);
+    public void Information(string messageTemplate, params object[] args) => Log(LogLevel.Information, messageTemplate, null, args);
+    public void Warning(string messageTemplate, params object[] args) => Log(LogLevel.Warning, messageTemplate, null, args);
+    public void Warning(Exception exception, string messageTemplate, params object[] args) => Log(LogLevel.Warning, messageTemplate, exception, args);
+    public void Error(string messageTemplate, params object[] args) => Log(LogLevel.Error, messageTemplate, null, args);
+    public void Error(Exception exception, string messageTemplate, params object[] args) => Log(LogLevel.Error, messageTemplate, exception, args);
+}

--- a/Common/Logging/ILogger.cs
+++ b/Common/Logging/ILogger.cs
@@ -1,0 +1,11 @@
+namespace Common.Logging;
+
+public interface ILogger
+{
+    void Debug(string messageTemplate, params object[] args);
+    void Information(string messageTemplate, params object[] args);
+    void Warning(string messageTemplate, params object[] args);
+    void Warning(System.Exception exception, string messageTemplate, params object[] args);
+    void Error(string messageTemplate, params object[] args);
+    void Error(System.Exception exception, string messageTemplate, params object[] args);
+}

--- a/Common/Logging/LogEvent.cs
+++ b/Common/Logging/LogEvent.cs
@@ -24,13 +24,24 @@ public record LogEvent
     public string MessageTemplate { get; init; }
     public object[]? Parameters { get; init; }
     public CsvPayload? CsvPayload { get; init; }
+    public System.Exception? Exception { get; init; }
+    public System.Collections.Generic.IReadOnlyList<(string Key, object Value)>? Context { get; init; }
 
-    public LogEvent(DateTime timestamp, LogLevel level, string messageTemplate, object[]? parameters = null, CsvPayload? csvPayload = null)
+    public LogEvent(
+        DateTime timestamp,
+        LogLevel level,
+        string messageTemplate,
+        object[]? parameters = null,
+        CsvPayload? csvPayload = null,
+        System.Collections.Generic.IReadOnlyList<(string Key, object Value)>? context = null,
+        System.Exception? exception = null)
     {
         Timestamp = timestamp;
         Level = level;
         MessageTemplate = messageTemplate;
         Parameters = parameters is null ? null : (object[])parameters.Clone();
         CsvPayload = csvPayload;
+        Context = context;
+        Exception = exception;
     }
 }

--- a/Common/Logging/LoggingService.cs
+++ b/Common/Logging/LoggingService.cs
@@ -52,17 +52,23 @@ public sealed class LoggingService : IDisposable, IAsyncDisposable
         }, _cts.Token);
     }
 
+    public ILogger CreateContextLogger(params (string Key, object Value)[] contextProperties)
+        => new ContextLogger(this, contextProperties);
+
+    public ILogger CreateLogger<T>()
+        => CreateContextLogger(("SourceContext", typeof(T).FullName ?? typeof(T).Name));
+
     /// <summary>
     /// Enqueues a log event to be processed by the background consumer.
     /// </summary>
-    public void Log(LogLevel level, string template, params object[] args)
+    public void Log(LogLevel level, string template, object[] args, Exception? exception = null, IReadOnlyList<(string Key, object Value)>? context = null)
     {
         if (_channel is null)
         {
             throw new InvalidOperationException("LoggingService has not been started.");
         }
 
-        var logEvent = new LogEvent(DateTime.UtcNow, level, template, args);
+        var logEvent = new LogEvent(DateTime.UtcNow, level, template, args, null, context, exception);
         _channel.Writer.TryWrite(logEvent);
     }
 

--- a/Common/Logging/Sinks/SerilogSink.cs
+++ b/Common/Logging/Sinks/SerilogSink.cs
@@ -20,13 +20,36 @@ public sealed class SerilogSink : ILogSink
             _ => LogEventLevel.Information
         };
 
+        ILogger logger = Log.Logger;
+        if (evt.Context is { } ctx)
+        {
+            foreach (var (key, value) in ctx)
+            {
+                logger = logger.ForContext(key, value);
+            }
+        }
+
         if (evt.Parameters is { Length: > 0 })
         {
-            Log.Write(level, evt.MessageTemplate, evt.Parameters);
+            if (evt.Exception is not null)
+            {
+                logger.Write(level, evt.Exception, evt.MessageTemplate, evt.Parameters);
+            }
+            else
+            {
+                logger.Write(level, evt.MessageTemplate, evt.Parameters);
+            }
         }
         else
         {
-            Log.Write(level, evt.MessageTemplate);
+            if (evt.Exception is not null)
+            {
+                logger.Write(level, evt.Exception, evt.MessageTemplate);
+            }
+            else
+            {
+                logger.Write(level, evt.MessageTemplate);
+            }
         }
     }
 }

--- a/EpcListGenerator/EpcListGeneratorHelper.cs
+++ b/EpcListGenerator/EpcListGeneratorHelper.cs
@@ -5,7 +5,6 @@ using System.Security.Cryptography;
 using Impinj.TagUtils;
 using OctaneTagWritingTest.Helpers;
 using TagDataTranslation;
-using Serilog;
 using Common.Logging;
 
 namespace EpcListGenerator
@@ -16,7 +15,7 @@ namespace EpcListGenerator
     public sealed class EpcListGeneratorHelper
     {
         private static readonly TDTEngine _tdtEngine = new();
-        private static readonly ILogger Logger = Log.ForContext<EpcListGeneratorHelper>();
+        private static readonly ILogger Logger = LoggingService.Instance.CreateLogger<EpcListGeneratorHelper>();
 
         // Lazy initialization of the singleton instance (thread-safe).
         private static readonly Lazy<EpcListGeneratorHelper> instance =

--- a/EpcListGenerator/Program.cs
+++ b/EpcListGenerator/Program.cs
@@ -3,15 +3,20 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Serilog;
+using Common.Logging;
+using Common.Logging.Sinks;
 
 namespace EpcListGenerator
 {
     internal class Program
     {
-        private static readonly ILogger Logger = Log.ForContext<Program>();
+        private static readonly ILogger Logger = LoggingService.Instance.CreateLogger<Program>();
         // Entry point now supports async operations.
         static async Task Main(string[] args)
         {
+            Log.Logger = new LoggerConfiguration().WriteTo.Console().CreateLogger();
+            var sinks = new ILogSink[] { new SerilogSink() };
+            LoggingService.Instance.Start(new Common.Logging.LoggingConfiguration(sinks));
             try
             {
                 // Parse command-line arguments or prompt the user for input.

--- a/OctaneTagWritingTest/BaseTestStrategy.cs
+++ b/OctaneTagWritingTest/BaseTestStrategy.cs
@@ -9,7 +9,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Serilog;
+using Common.Logging;
 
 namespace OctaneTagWritingTest
 {

--- a/OctaneTagWritingTest/Helpers/EpcListManager.cs
+++ b/OctaneTagWritingTest/Helpers/EpcListManager.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using TagDataTranslation;
-using Serilog;
+using Common.Logging;
 using OctaneTagWritingTest;
 
 public sealed class EpcListManager

--- a/OctaneTagWritingTest/Helpers/TagOpController.cs
+++ b/OctaneTagWritingTest/Helpers/TagOpController.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
-using Serilog;
 using Common.Logging;
 using OctaneTagWritingTest.Infrastructure;
 

--- a/OctaneTagWritingTest/JobManager.cs
+++ b/OctaneTagWritingTest/JobManager.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Serilog;
+using Common.Logging;
 
 namespace OctaneTagWritingTest
 {

--- a/OctaneTagWritingTest/JobStrategies/JobStrategy0ReadOnlyLogging.cs
+++ b/OctaneTagWritingTest/JobStrategies/JobStrategy0ReadOnlyLogging.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
-using Serilog;
+using Common.Logging;
 
 namespace OctaneTagWritingTest.JobStrategies
 {

--- a/OctaneTagWritingTest/JobStrategies/JobStrategy9CheckBox.cs
+++ b/OctaneTagWritingTest/JobStrategies/JobStrategy9CheckBox.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 using Impinj.OctaneSdk;
 using OctaneTagWritingTest.Helpers;
 using Org.LLRP.LTK.LLRPV1.Impinj;
-using Serilog;
+using Common.Logging;
 using OctaneTagWritingTest.Infrastructure;
 
 namespace OctaneTagWritingTest.JobStrategies

--- a/OctaneTagWritingTest/LoggingConfiguration.cs
+++ b/OctaneTagWritingTest/LoggingConfiguration.cs
@@ -58,14 +58,7 @@ namespace OctaneTagWritingTest
         /// <returns>Contextual logger instance</returns>
         public static ILogger CreateContextLogger(params (string Key, object Value)[] contextProperties)
         {
-            var logger = Log.Logger;
-            
-            foreach (var (key, value) in contextProperties)
-            {
-                logger = logger.ForContext(key, value);
-            }
-            
-            return logger;
+            return LoggingService.Instance.CreateContextLogger(contextProperties);
         }
 
         /// <summary>
@@ -75,7 +68,7 @@ namespace OctaneTagWritingTest
         /// <returns>Logger with source context</returns>
         public static ILogger CreateLogger<T>()
         {
-            return Log.ForContext<T>();
+            return LoggingService.Instance.CreateLogger<T>();
         }
 
         /// <summary>
@@ -86,9 +79,10 @@ namespace OctaneTagWritingTest
         /// <returns>Logger with tag operation context</returns>
         public static ILogger CreateTagOperationLogger(string tid, string operation)
         {
-            return Log.ForContext("TID", tid)
-                     .ForContext("Operation", operation)
-                     .ForContext("Component", "TagOperation");
+            return LoggingService.Instance.CreateContextLogger(
+                ("TID", tid),
+                ("Operation", operation),
+                ("Component", "TagOperation"));
         }
 
         /// <summary>
@@ -99,9 +93,10 @@ namespace OctaneTagWritingTest
         /// <returns>Logger with reader context</returns>
         public static ILogger CreateReaderLogger(string readerName, string hostname)
         {
-            return Log.ForContext("ReaderName", readerName)
-                     .ForContext("ReaderHostname", hostname)
-                     .ForContext("Component", "Reader");
+            return LoggingService.Instance.CreateContextLogger(
+                ("ReaderName", readerName),
+                ("ReaderHostname", hostname),
+                ("Component", "Reader"));
         }
 
         /// <summary>
@@ -111,8 +106,9 @@ namespace OctaneTagWritingTest
         /// <returns>Logger with strategy context</returns>
         public static ILogger CreateStrategyLogger(string strategyName)
         {
-            return Log.ForContext("Strategy", strategyName)
-                     .ForContext("Component", "JobStrategy");
+            return LoggingService.Instance.CreateContextLogger(
+                ("Strategy", strategyName),
+                ("Component", "JobStrategy"));
         }
 
         /// <summary>

--- a/OctaneTagWritingTest/Program.cs
+++ b/OctaneTagWritingTest/Program.cs
@@ -1,6 +1,7 @@
 ﻿﻿using OctaneTagWritingTest.Helpers;
 using System.Diagnostics;
-using Serilog;
+using Common.Logging;
+using Serilog.Events;
 
 namespace OctaneTagWritingTest
 {
@@ -15,7 +16,7 @@ namespace OctaneTagWritingTest
             Console.Title = "Serializer";
 
             // Initialize structured logging first
-            LoggingConfiguration.ConfigureLogging("main", Serilog.Events.LogEventLevel.Information);
+            LoggingConfiguration.ConfigureLogging("main", LogEventLevel.Information);
             Logger.Information("Application starting with arguments: {Arguments}", args);
 
             // The .NET diagnostics trace listener configuration

--- a/TagUtils.Tests/StrategyFlowTests.cs
+++ b/TagUtils.Tests/StrategyFlowTests.cs
@@ -3,6 +3,8 @@ using System.Linq;
 using NUnit.Framework;
 using Serilog;
 using Serilog.Sinks.InMemory;
+using Common.Logging;
+using Common.Logging.Sinks;
 using Snapshooter.NUnit;
 
 namespace TagUtils.Tests;
@@ -11,7 +13,7 @@ public class StrategyFlowTests
 {
     private class InstrumentedStrategy
     {
-        private readonly ILogger _logger = Log.ForContext("Strategy", "Test");
+        private readonly ILogger _logger = LoggingService.Instance.CreateContextLogger(("Strategy", "Test"));
         public List<string> Steps { get; } = new();
 
         public void Start()
@@ -44,6 +46,9 @@ public class StrategyFlowTests
     {
         var logger = new LoggerConfiguration().WriteTo.InMemory().CreateLogger();
         Log.Logger = logger;
+        var sink = new SerilogSink();
+        var cfg = new Common.Logging.LoggingConfiguration(new ILogSink[] { sink });
+        LoggingService.Instance.Start(cfg);
 
         var strategy = new InstrumentedStrategy();
         strategy.Start();
@@ -51,6 +56,7 @@ public class StrategyFlowTests
         strategy.Run();
         strategy.Stop();
 
+        LoggingService.Instance.Stop();
         var logMessages = InMemorySink.Instance.LogEvents.Select(e => e.RenderMessage()).ToList();
         Snapshot.Match(logMessages);
 

--- a/TagUtils/TagUtils/MssFormula.cs
+++ b/TagUtils/TagUtils/MssFormula.cs
@@ -2,13 +2,13 @@
 using System;
 using System.Text;
 using System.Text.RegularExpressions;
-using Serilog;
+using Common.Logging;
 
 namespace Impinj.TagUtils
 {
     public class MssFormula
     {
-        private static readonly ILogger Logger = Log.ForContext<MssFormula>();
+        private static readonly ILogger Logger = LoggingService.Instance.CreateLogger<MssFormula>();
         private static string ZeroedOut96BitValue = string.Empty.PadLeft(96, '0');
 
         public static string GenerateMssSerialNumberWithSerializationPrefix(


### PR DESCRIPTION
## Summary
- add context-aware `ILogger` and wrapper for asynchronous LoggingService
- enrich log events with context and exceptions for Serilog sinks
- replace direct `Log.ForContext` usage with LoggingService helpers across projects

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c09d374bb8832383c22032e64acba9