### PR TITLE
Add unit tests for logging service and CSV sink

### DIFF
--- a/Logging.Tests/CsvSinkTests.cs
+++ b/Logging.Tests/CsvSinkTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Common.Logging;
+using Common.Logging.Sinks;
+
+namespace Logging.Tests;
+
+public class CsvSinkTests
+{
+    private static LoggingService CreateService(params ILogSink[] sinks)
+    {
+        var service = (LoggingService)Activator.CreateInstance(typeof(LoggingService), nonPublic: true)!;
+        service.Start(new LoggingConfiguration(sinks));
+        return service;
+    }
+
+    [Test]
+    public async Task CsvSink_Writes_Header_Once_And_Batches_Lines()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(directory);
+        var file = Path.Combine(directory, "log.csv");
+        var sink = new CsvSink();
+        var svc = CreateService(sink);
+        for (var i = 0; i < 60; i++)
+        {
+            svc.LogCsv(file, "col1,col2", $"{i},data{i}");
+        }
+        await svc.FlushAsync();
+        var lines = await File.ReadAllLinesAsync(file);
+        Assert.That(lines[0], Is.EqualTo("col1,col2"));
+        var expected = Enumerable.Range(0, 60).Select(i => $"{i},data{i}");
+        Assert.That(lines.Skip(1), Is.EqualTo(expected));
+        Assert.That(lines.Count(l => l == "col1,col2"), Is.EqualTo(1));
+    }
+}

--- a/Logging.Tests/GlobalUsings.cs
+++ b/Logging.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/Logging.Tests/Logging.Tests.csproj
+++ b/Logging.Tests/Logging.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Common\**\*.cs" Link="Common\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Remove="..\Common\Logging\Sinks\SerilogSink.cs" />
+  </ItemGroup>
+</Project>

--- a/Logging.Tests/LoggingServiceTests.cs
+++ b/Logging.Tests/LoggingServiceTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Common.Logging;
+using Common.Logging.Sinks;
+
+namespace Logging.Tests;
+
+public class LoggingServiceTests
+{
+    private static LoggingService CreateService(params ILogSink[] sinks)
+    {
+        var service = (LoggingService)Activator.CreateInstance(typeof(LoggingService), nonPublic: true)!;
+        service.Start(new LoggingConfiguration(sinks));
+        return service;
+    }
+
+    private sealed class TestSink : ILogSink
+    {
+        public List<LogEvent> Events { get; } = new();
+        public void Write(LogEvent evt) => Events.Add(evt);
+    }
+
+    private sealed class SlowSink : ILogSink
+    {
+        private readonly int _delayMs;
+        public List<LogEvent> Events { get; } = new();
+        public SlowSink(int delayMs) => _delayMs = delayMs;
+        public void Write(LogEvent evt)
+        {
+            Thread.Sleep(_delayMs);
+            Events.Add(evt);
+        }
+    }
+
+    [Test]
+    public async Task Events_Are_Processed_In_FIFO_Order()
+    {
+        var sink = new TestSink();
+        var svc = CreateService(sink);
+        svc.LogInfo("first");
+        svc.LogInfo("second");
+        svc.LogInfo("third");
+        await svc.FlushAsync();
+        var templates = sink.Events.Select(e => e.MessageTemplate).ToList();
+        Assert.That(templates, Is.EqualTo(new[] { "first", "second", "third" }));
+    }
+
+    [Test]
+    public async Task FlushAsync_Drains_Remaining_Events()
+    {
+        var sink = new SlowSink(10);
+        var svc = CreateService(sink);
+        for (var i = 0; i < 20; i++)
+        {
+            svc.LogInfo("msg {0}", i);
+        }
+        await svc.FlushAsync();
+        Assert.That(sink.Events.Count, Is.EqualTo(20));
+    }
+}


### PR DESCRIPTION
## Summary
- add Logging.Tests project with NUnit
- verify events processed in FIFO order
- ensure CsvSink writes header once and handles batched lines
- confirm FlushAsync drains remaining events

## Testing
- `~/.dotnet/dotnet test Logging.Tests/Logging.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c0ce0f206c83238b3c5629b6ea77a3