### PR TITLE
Fix Serilog sink logger type

### DIFF
--- a/Common/Logging/Sinks/SerilogSink.cs
+++ b/Common/Logging/Sinks/SerilogSink.cs
@@ -20,7 +20,7 @@ public sealed class SerilogSink : ILogSink
             _ => LogEventLevel.Information
         };
 
-        ILogger logger = Log.Logger;
+        Serilog.ILogger logger = Log.Logger;
         if (evt.Context is { } ctx)
         {
             foreach (var (key, value) in ctx)


### PR DESCRIPTION
## Summary
- resolve the ambiguous logger assignment in the Serilog sink by explicitly using the Serilog logger type

## Testing
- dotnet build OctaneTagWritingTest/OctaneTagWritingTest.csproj *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cc334381588323b27c5dfc83179746