### PR TITLE
Resolve ILogger ambiguity in Program

### DIFF
--- a/EpcListGenerator/Program.cs
+++ b/EpcListGenerator/Program.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Serilog;
 using Common.Logging;
 using Common.Logging.Sinks;
+using ILogger = Common.Logging.ILogger;
 
 namespace EpcListGenerator
 {


### PR DESCRIPTION
## Summary
- alias `Common.Logging.ILogger` in `Program.cs` to avoid ambiguity with `Serilog.ILogger`

## Testing
- `dotnet build EpcListGenerator/EpcListGenerator.sln` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc35887c808323ad39b3356904977e