### PR TITLE
refactor: centralize shared logging project

### DIFF
--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="3.1.1" />
+  </ItemGroup>
+</Project>

--- a/EpcListGenerator/EpcListGenerator.csproj
+++ b/EpcListGenerator/EpcListGenerator.csproj
@@ -27,11 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Common\Common.csproj" />
     <ProjectReference Include="..\TagUtils\TagUtils.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Include="..\Common\**\*.cs" Link="Common\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
 </Project>

--- a/EpcListGenerator/EpcListGenerator.sln
+++ b/EpcListGenerator/EpcListGenerator.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EpcListGenerator", "EpcList
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TagUtils", "..\TagUtils\TagUtils.csproj", "{6890F730-1411-4C86-A21E-778287247E1F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common", "..\Common\Common.csproj", "{86334808-9E4A-4A32-BECD-4E5A25598BC5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{6890F730-1411-4C86-A21E-778287247E1F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6890F730-1411-4C86-A21E-778287247E1F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6890F730-1411-4C86-A21E-778287247E1F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{86334808-9E4A-4A32-BECD-4E5A25598BC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86334808-9E4A-4A32-BECD-4E5A25598BC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86334808-9E4A-4A32-BECD-4E5A25598BC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{86334808-9E4A-4A32-BECD-4E5A25598BC5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Logging.Tests/Logging.Tests.csproj
+++ b/Logging.Tests/Logging.Tests.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\Common\**\*.cs" Link="Common\%(RecursiveDir)%(Filename)%(Extension)" />
-    <Compile Remove="..\Common\Logging\Sinks\SerilogSink.cs" />
+    <ProjectReference Include="..\Common\Common.csproj" />
   </ItemGroup>
 </Project>

--- a/OctaneTagWritingTest/OctaneTagWritingTest.csproj
+++ b/OctaneTagWritingTest/OctaneTagWritingTest.csproj
@@ -21,14 +21,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\Common\**\*.cs" Link="Common\%(RecursiveDir)%(Filename)%(Extension)" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Folder Include="etk_deploy\" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Common\Common.csproj" />
     <ProjectReference Include="..\EpcListGenerator\EpcListGenerator.csproj" />
     <ProjectReference Include="..\TagUtils\TagUtils.csproj" />
   </ItemGroup>

--- a/OctaneTagWritingTest/OctaneTagWritingTest.sln
+++ b/OctaneTagWritingTest/OctaneTagWritingTest.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TagUtils", "..\TagUtils\Tag
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EpcListGenerator", "..\EpcListGenerator\EpcListGenerator.csproj", "{55F4667B-6F0D-4876-8AAF-12D8ADEB56B2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common", "..\Common\Common.csproj", "{86334808-9E4A-4A32-BECD-4E5A25598BC5}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TagUtils.Tests", "..\TagUtils.Tests\TagUtils.Tests.csproj", "{0D29D398-38F6-D40C-911D-7CC7440ECC99}"
 EndProject
 Global
@@ -29,6 +31,10 @@ Global
 		{55F4667B-6F0D-4876-8AAF-12D8ADEB56B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{55F4667B-6F0D-4876-8AAF-12D8ADEB56B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{55F4667B-6F0D-4876-8AAF-12D8ADEB56B2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{86334808-9E4A-4A32-BECD-4E5A25598BC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86334808-9E4A-4A32-BECD-4E5A25598BC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86334808-9E4A-4A32-BECD-4E5A25598BC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{86334808-9E4A-4A32-BECD-4E5A25598BC5}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0D29D398-38F6-D40C-911D-7CC7440ECC99}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0D29D398-38F6-D40C-911D-7CC7440ECC99}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0D29D398-38F6-D40C-911D-7CC7440ECC99}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/TagUtils.Tests/TagUtils.Tests.csproj
+++ b/TagUtils.Tests/TagUtils.Tests.csproj
@@ -21,12 +21,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Common\Common.csproj" />
     <ProjectReference Include="..\EpcListGenerator\EpcListGenerator.csproj" />
     <ProjectReference Include="..\TagUtils\TagUtils.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Include="..\Common\**\*.cs" Link="Common\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
 </Project>

--- a/TagUtils/TagUtils.csproj
+++ b/TagUtils/TagUtils.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\Common\**\*.cs" Link="Common\%(RecursiveDir)%(Filename)%(Extension)" />
+    <ProjectReference Include="..\Common\Common.csproj" />
   </ItemGroup>
 
 </Project>

--- a/TagUtils/TagUtils.sln
+++ b/TagUtils/TagUtils.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.12.35728.132 d17.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TagUtils", "TagUtils.csproj", "{FEAC51D3-2604-40EB-B1DB-6583E009B490}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common", "..\Common\Common.csproj", "{86334808-9E4A-4A32-BECD-4E5A25598BC5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{FEAC51D3-2604-40EB-B1DB-6583E009B490}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FEAC51D3-2604-40EB-B1DB-6583E009B490}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FEAC51D3-2604-40EB-B1DB-6583E009B490}.Release|Any CPU.Build.0 = Release|Any CPU
+		{86334808-9E4A-4A32-BECD-4E5A25598BC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86334808-9E4A-4A32-BECD-4E5A25598BC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86334808-9E4A-4A32-BECD-4E5A25598BC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{86334808-9E4A-4A32-BECD-4E5A25598BC5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add a dedicated Common class library that hosts the shared logging infrastructure
- update all project and solution files to reference the Common project instead of linking source files directly

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cc36192cf88323be95566802ff7613