### PR TITLE
Allow restarting LoggingService after stop

### DIFF
--- a/Common/Logging/LoggingService.cs
+++ b/Common/Logging/LoggingService.cs
@@ -102,20 +102,26 @@ public sealed class LoggingService : IDisposable, IAsyncDisposable
       /// </summary>
       public async Task FlushAsync()
       {
-          if (_channel is null)
+          var channel = _channel;
+          if (channel is null)
           {
               return;
           }
 
-          _channel.Writer.Complete();
-          if (_consumerTask is not null)
+          var consumerTask = _consumerTask;
+          var sinks = _sinks;
+          var cts = _cts;
+
+          channel.Writer.Complete();
+
+          if (consumerTask is not null)
           {
-              await _consumerTask.ConfigureAwait(false);
+              await consumerTask.ConfigureAwait(false);
           }
 
-          if (_sinks is not null)
+          if (sinks is not null)
           {
-              foreach (var sink in _sinks)
+              foreach (var sink in sinks)
               {
                   switch (sink)
                   {
@@ -128,6 +134,14 @@ public sealed class LoggingService : IDisposable, IAsyncDisposable
                   }
               }
           }
+
+          cts?.Cancel();
+          cts?.Dispose();
+
+          _channel = null;
+          _consumerTask = null;
+          _sinks = null;
+          _cts = null;
       }
 
     /// <summary>

--- a/Logging.Tests/LoggingServiceTests.cs
+++ b/Logging.Tests/LoggingServiceTests.cs
@@ -60,4 +60,20 @@ public class LoggingServiceTests
         await svc.FlushAsync();
         Assert.That(sink.Events.Count, Is.EqualTo(20));
     }
+
+    [Test]
+    public async Task Service_Can_Be_Restarted_After_Stop()
+    {
+        var sink = new TestSink();
+        var svc = CreateService(sink);
+
+        svc.LogInfo("first run");
+        svc.Stop();
+
+        svc.Start(new LoggingConfiguration(new[] { sink }));
+        svc.LogInfo("second run");
+        await svc.FlushAsync();
+
+        Assert.That(sink.Events.Select(e => e.MessageTemplate), Is.EqualTo(new[] { "first run", "second run" }));
+    }
 }


### PR DESCRIPTION
## Summary
- reset the logging service resources during FlushAsync so Start can be called again
- add a regression test that verifies log events are still delivered after restarting the service

## Testing
- `dotnet test Logging.Tests` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4f72be5883239e54b2518376bf24