### PR TITLE
Sanitize configuration defaults and template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ OctaneTagWritingTest/.vs/ProjectEvaluation/octanetagwritingtest.projects.v9.bin
 OctaneTagWritingTest/.vs/ProjectEvaluation/octanetagwritingtest.strings.v9.bin
 OctaneTagWritingTest/obj/Container/AbsoluteOutputAssemblyPath.cache
 OctaneTagWritingTest/obj/Container/AdditionalProbingPaths.cache
+OctaneTagWritingTest/config.json
 OctaneTagWritingTest/obj/Container/ContainerDevelopmentMode.cache
 OctaneTagWritingTest/obj/Container/ContainerId.cache
 OctaneTagWritingTest/obj/Container/ContainerName.cache

--- a/OctaneTagWritingTest/ApplicationConfig.cs
+++ b/OctaneTagWritingTest/ApplicationConfig.cs
@@ -7,22 +7,22 @@
 public class ApplicationConfig
 {
     // Reader network settings
-    // Leaving hostnames empty allows running strategies with a subset of readers
+    // Defaults use placeholder hostnames; clear a value to disable the corresponding reader
 
     /// <summary>
-    /// Hostname or IP of the detector reader. Default: empty (disabled).
+    /// Hostname or IP of the detector reader. Default: "detector.example.com".
     /// </summary>
-    public string DetectorHostname { get; set; } = string.Empty;
+    public string DetectorHostname { get; set; } = "detector.example.com";
 
     /// <summary>
-    /// Hostname or IP of the writer reader. Default: empty (disabled).
+    /// Hostname or IP of the writer reader. Default: "writer.example.com".
     /// </summary>
-    public string WriterHostname { get; set; } = string.Empty;
+    public string WriterHostname { get; set; } = "writer.example.com";
 
     /// <summary>
-    /// Hostname or IP of the verifier reader. Default: empty (disabled).
+    /// Hostname or IP of the verifier reader. Default: "verifier.example.com".
     /// </summary>
-    public string VerifierHostname { get; set; } = string.Empty;
+    public string VerifierHostname { get; set; } = "verifier.example.com";
 
     /// <summary>
     /// Enables SGTIN-96 EPC generation. Default: <c>true</c>.
@@ -30,15 +30,15 @@ public class ApplicationConfig
     public bool Sgtin96Enabled { get; set; } = true;
 
     /// <summary>
-    /// Base GTIN used for SGTIN-96 generation. Default: empty.
+    /// Base GTIN used for SGTIN-96 generation. Default: "00000000000000".
     /// </summary>
-    public string Sgtin96SourceGtin { get; set; } = "";
+    public string Sgtin96SourceGtin { get; set; } = "00000000000000";
 
     // Test parameters
     /// <summary>
-    /// Description used in log file names. Default: "Teste11-Aplicador-Integrado".
+    /// Description used in log file names. Default: "Sample Integration Test".
     /// </summary>
-    public string TestDescription { get; set; } = "Teste11-Aplicador-Integrado";
+    public string TestDescription { get; set; } = "Sample Integration Test";
 
     /// <summary>
     /// EPC header value in hexadecimal. Default: "B6".
@@ -46,14 +46,14 @@ public class ApplicationConfig
     public string EpcHeader { get; set; } = "B6";
 
     /// <summary>
-    /// EPC item identifier without the header. Default: "33449900112222".
+    /// EPC item identifier without the header. Default: "00000000000000".
     /// </summary>
-    public string EpcPlainItemCode { get; set; } = "33449900112222";
+    public string EpcPlainItemCode { get; set; } = "00000000000000";
 
     /// <summary>
-    /// Stock keeping unit identifier. Default: "334499001122".
+    /// Stock keeping unit identifier. Default: "000000000000".
     /// </summary>
-    public string Sku { get; set; } = "334499001122";
+    public string Sku { get; set; } = "000000000000";
 
     /// <summary>
     /// Number of tags to generate. Default: 1 tag.

--- a/OctaneTagWritingTest/README.md
+++ b/OctaneTagWritingTest/README.md
@@ -112,7 +112,15 @@ JobStrategy8 (Multiple Reader Endurance) supports configurable behavior when the
   - "Offset": Compare EPCs starting from a given character offset (default)
 - VerifierEpcCompareOffset: The starting character index when using Offset mode (default: 13)
 
-Example configuration (OctaneTagWritingTest/config.json):
+### Configuration
+
+1. Copy `OctaneTagWritingTest/config.example.json` to `OctaneTagWritingTest/config.json`.
+2. Replace the placeholder hostnames, GTIN, SKU, and any other environment-specific values with your production settings.
+3. Keep `config.json` out of source control so sensitive infrastructure details remain local only.
+
+The application loads settings from `config.json` at runtime. If the file is absent, the built-in defaults shown in `ApplicationConfig.cs` are used.
+
+Example override file (`OctaneTagWritingTest/config.json`):
 
 ```
 {

--- a/OctaneTagWritingTest/config.example.json
+++ b/OctaneTagWritingTest/config.example.json
@@ -1,8 +1,8 @@
 {
-  "DetectorHostname": "192.168.1.3",
-  "WriterHostname": "192.168.1.4",
-  "VerifierHostname": "192.168.1.5",
-  "TestDescription": "Testes Fareva",
+  "DetectorHostname": "detector.example.com",
+  "WriterHostname": "writer.example.com",
+  "VerifierHostname": "verifier.example.com",
+  "TestDescription": "Sample Integration Test",
   "UseGpiForVerification": true,
   "GpiPortToProcessVerification": 1,
   "GpiTriggerStateToProcessVerification": true,
@@ -13,11 +13,11 @@
   "VerifierRewriteOnMismatch": true,
 
   "Sgtin96Enabled": true,
-  "Sgtin96SourceGtin": "07891033625888",
+  "Sgtin96SourceGtin": "00000000000000",
 
-  "EpcHeader": "B1",
-  "EpcPlainItemCode": "07891033625888",
-  "Sku": "7891033625888",
+  "EpcHeader": "B6",
+  "EpcPlainItemCode": "00000000000000",
+  "Sku": "000000000000",
 
   "Quantity": 1,
 


### PR DESCRIPTION
## Summary
- replace the checked-in configuration with a sanitized `config.example.json` template that uses placeholder hostnames, GTIN, and SKU
- document how to copy the template to a local `config.json` and keep the real settings out of source control
- align `ApplicationConfig` string defaults with the neutral placeholder values and ignore the real `config.json`

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d4209914e8832391bb26e7bc5cec49