### PR TITLE
Sanitize docker configuration host placeholders

### DIFF
--- a/OctaneTagWritingTest/Properties/launchSettings.json
+++ b/OctaneTagWritingTest/Properties/launchSettings.json
@@ -6,7 +6,7 @@
     },
     "Container (Dockerfile)": {
       "commandName": "Docker",
-      "commandLineArgs": "192.168.68.248  192.168.68.94"
+      "commandLineArgs": "[detector-hostname] [writer-hostname] [verifier-hostname]"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -243,8 +243,10 @@ docker build --build-arg BUILD_CONFIGURATION=Debug -t octane-tag-writing-test .
 docker run octane-tag-writing-test [detector-hostname] [writer-hostname] [verifier-hostname]
 
 # Execução com configurações específicas
-docker run octane-tag-writing-test 192.168.68.248 192.168.68.94 192.168.68.100
+docker run octane-tag-writing-test [detector-hostname] [writer-hostname] [verifier-hostname]
 ```
+
+> Substitua os placeholders `[detector-hostname]`, `[writer-hostname]` e `[verifier-hostname]` pelos hostnames ou endereços IP reais dos leitores utilizados.
 
 ### Otimizações Docker
 


### PR DESCRIPTION
## Summary
- replace the Docker launch profile arguments with placeholder hostnames instead of hard-coded IPs
- update the README Docker run example and accompanying note to use the same sanitized placeholders

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d42199f2788323a3dc10ba7f1cb505