### PR TITLE
Remove user-specific project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -448,3 +448,5 @@ TagUtils/bin/Release/net8.0/TagUtils.pdb
 /TagUtils/obj
 /TagUtils/obj
 /TagUtils/obj
+
+*.csproj.user

--- a/EpcListGenerator/EpcListGenerator.csproj.user
+++ b/EpcListGenerator/EpcListGenerator.csproj.user
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <ActiveDebugProfile>EpcListGenerator</ActiveDebugProfile>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
-  </PropertyGroup>
-</Project>

--- a/OctaneTagWritingTest/OctaneTagWritingTest.csproj.user
+++ b/OctaneTagWritingTest/OctaneTagWritingTest.csproj.user
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <ActiveDebugProfile>OctaneTagWritingTest</ActiveDebugProfile>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
-  </PropertyGroup>
-</Project>


### PR DESCRIPTION
## Summary
- stop tracking the OctaneTagWritingTest and EpcListGenerator .csproj.user files that should be per-developer only
- add a *.csproj.user rule to the repository .gitignore to prevent future commits of these files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4329e34688323ae7d4e93ea637bc6