### PR TITLE
Fix asynchronous beep helper return type

### DIFF
--- a/OctaneTagWritingTest/JobStrategies/JobStrategy8MultipleReaderEnduranceStrategy.cs
+++ b/OctaneTagWritingTest/JobStrategies/JobStrategy8MultipleReaderEnduranceStrategy.cs
@@ -785,15 +785,17 @@ namespace OctaneTagWritingTest.JobStrategies
         public Task BeepAsync()
         {
             return BeepAsync(1000, 500);
-
         }
+
         // Updated method to handle platform-specific code for Console.Beep
-        public void BeepAsync(int frequency, int duration)
+        public Task BeepAsync(int frequency, int duration)
         {
             if (OperatingSystem.IsWindows())
             {
-                _ = Task.Run(() => Console.Beep(frequency, duration));
+                return Task.Run(() => Console.Beep(frequency, duration));
             }
+
+            return Task.CompletedTask;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- ensure `BeepAsync` overload returns a `Task` so the strategy compiles under .NET 8

## Testing
- dotnet build OctaneTagWritingTest/OctaneTagWritingTest.sln
- dotnet build TagUtils/TagUtils.sln
- dotnet build EpcListGenerator/EpcListGenerator.sln
- dotnet build Logging.Tests/Logging.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d43cd950c8832385e56f78b88da2df